### PR TITLE
fix small issues:

### DIFF
--- a/lib/ecto/paging.ex
+++ b/lib/ecto/paging.ex
@@ -110,11 +110,11 @@ defmodule Ecto.Paging do
   end
 
   def get_next_paging(query_result, %Ecto.Paging{limit: limit, cursors: cursors}) when is_list(query_result) do
-    has_more = length(query_result) >= limit
+    has_more = length(query_result) > limit
     %Ecto.Paging{
       limit: limit,
       has_more: has_more,
-      cursors: get_next_cursors(query_result, cursors, has_more)
+      cursors: get_next_cursors(query_result, cursors)
     }
   end
 
@@ -122,16 +122,16 @@ defmodule Ecto.Paging do
     get_next_paging(query_result, Ecto.Paging.from_map(paging))
   end
 
-  defp get_next_cursors([], _, _) do
-      %Ecto.Paging.Cursors{starting_after: nil, ending_before: nil}
+  defp get_next_cursors([], _) do
+    %Ecto.Paging.Cursors{starting_after: nil, ending_before: nil}
   end
 
-  defp get_next_cursors(query_result, _, false) do
-    %Ecto.Paging.Cursors{starting_after: List.last(query_result).id,
-                          ending_before: nil}
+  defp get_next_cursors(query_result, %Ecto.Paging.Cursors{starting_after: nil}) do
+      %Ecto.Paging.Cursors{starting_after: List.last(query_result).id,
+                           ending_before: nil}
   end
 
-  defp get_next_cursors(query_result, _, true) do
+  defp get_next_cursors(query_result, _) do
       %Ecto.Paging.Cursors{starting_after: List.last(query_result).id,
                            ending_before: List.first(query_result).id}
   end

--- a/test/unit/ecto_paging_test.exs
+++ b/test/unit/ecto_paging_test.exs
@@ -184,6 +184,18 @@ defmodule Ecto.PagingTest do
       assert paging.has_more
     end
 
+    test "ending_before is not nil" do
+      {[head | _] = items, paging} = Ecto.Paging.TestRepo.page(Ecto.Paging.TestSchema, %{limit: 150})
+      assert 150 == Enum.count(items)
+      assert %{cursors: %{ending_before: ending_before}, has_more: false} = paging
+      assert head.id == ending_before
+    end
+
+    test "first page has not ending_before" do
+      {_, paging} = Ecto.Paging.TestRepo.page(Ecto.Paging.TestSchema, %{})
+      assert %{cursors: %{ending_before: nil}} = paging
+    end
+
     test "paginates forward with starting after with ordering" do
       res1 =
         get_query()


### PR DESCRIPTION
1. Set has_more to false if last page size is equal to limit
2. Set ending_before to nil if starting_after is not set in the query
3. Set ending_before at the last page